### PR TITLE
Relax util dep to ~0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./assert.js",
   "dependencies": {
-    "util": "0.10.2"
+    "util": "~0.10"
   },
   "devDependencies": {
     "zuul": "~1.0.9",


### PR DESCRIPTION
When using browserify, there are rare circumstances in which `require('util')` will resolve to 2 different file paths, resulting in the module being included twice in the output bundle. This is because assert pinned util at 0.10.2 while the latest version is 0.10.3, so util exists in node_modules/assert/node_modules and in node_modules.

This wouldn't matter in nodejs, but it affects browserify.

This relaxes the version requirements so that util will get deduped and resolved to a single file path from everywhere.
