### PR TITLE
Catch up Node.js assert updates

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -227,10 +227,11 @@ function objEquiv(a, b) {
   if (a.prototype !== b.prototype) return false;
   //~~~I've managed to break Object.keys through screwy arguments passing.
   //   Converting to array solves the problem.
-  if (isArguments(a)) {
-    if (!isArguments(b)) {
-      return false;
-    }
+  var aIsArgs = isArguments(a),
+      bIsArgs = isArguments(b);
+  if ((aIsArgs && !bIsArgs) || (!aIsArgs && bIsArgs))
+    return false;
+  if (aIsArgs) {
     a = pSlice.call(a);
     b = pSlice.call(b);
     return _deepEqual(a, b);

--- a/test.js
+++ b/test.js
@@ -264,6 +264,11 @@ test('assert - Make sure deepEqual doesn\'t loop forever on circular refs', func
   assert.ok(gotError);
 });
 
+test('assert - Ensure reflexivity of deepEqual with `arguments` objects', function() {
+    var args = (function() { return arguments; })();
+    assert.throws(makeBlock(assert.deepEqual, [], args), assert.AssertionError);
+    assert.throws(makeBlock(assert.deepEqual, args, []), assert.AssertionError);
+});
 
 test('assert - test assertion message', function () {
   function testAssertionMessage(actual, expected) {


### PR DESCRIPTION
- Fix bug of deepEqual: https://github.com/joyent/node/commit/aae51ecf7d407b2fb56c1f3e1edf91a16940c973
- Remove unnecessary isNaN(): https://github.com/joyent/node/commit/b87ca794e31096b61ead46911baf92ba1c020a7d#diff-1
