### PR TITLE
Fix deepEqual for ES6 Object.keys

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -225,8 +225,10 @@ function objEquiv(a, b) {
     return false;
   // an identical 'prototype' property.
   if (a.prototype !== b.prototype) return false;
-  //~~~I've managed to break Object.keys through screwy arguments passing.
-  //   Converting to array solves the problem.
+  // if one is a primitive, the other must be same
+  if (util.isPrimitive(a) || util.isPrimitive(b)) {
+    return a === b;
+  }
   var aIsArgs = isArguments(a),
       bIsArgs = isArguments(b);
   if ((aIsArgs && !bIsArgs) || (!aIsArgs && bIsArgs))
@@ -236,13 +238,9 @@ function objEquiv(a, b) {
     b = pSlice.call(b);
     return _deepEqual(a, b);
   }
-  try {
-    var ka = objectKeys(a),
-        kb = objectKeys(b),
-        key, i;
-  } catch (e) {//happens when one is a string literal and the other isn't
-    return false;
-  }
+  var ka = objectKeys(a),
+      kb = objectKeys(b),
+      key, i;
   // having the same number of owned properties (keys incorporates
   // hasOwnProperty)
   if (ka.length != kb.length)

--- a/test.js
+++ b/test.js
@@ -158,9 +158,25 @@ test('assert.deepEqual - instances', function () {
   nameBuilder2.prototype = Object;
   nb2 = new nameBuilder2('Ryan', 'Dahl');
   assert.throws(makeBlock(assert.deepEqual, nb1, nb2), assert.AssertionError);
+});
 
-  // String literal + object blew up my implementation...
-  assert.throws(makeBlock(assert.deepEqual, 'a', {}), assert.AssertionError);
+test('assert.deepEqual - ES6 primitives', function () {
+  assert.throws(makeBlock(assert.deepEqual, null, {}), assert.AssertionError);
+  assert.throws(makeBlock(assert.deepEqual, undefined, {}), assert.AssertionError);
+  assert.throws(makeBlock(assert.deepEqual, 'a', ['a']), assert.AssertionError);
+  assert.throws(makeBlock(assert.deepEqual, 'a', {0: 'a'}), assert.AssertionError);
+  assert.throws(makeBlock(assert.deepEqual, 1, {}), assert.AssertionError);
+  assert.throws(makeBlock(assert.deepEqual, true, {}), assert.AssertionError);
+  if (typeof Symbol === 'symbol') {
+    assert.throws(makeBlock(assert.deepEqual, Symbol(), {}), assert.AssertionError);
+  }
+});
+
+test('assert.deepEqual - object wrappers', function () {
+  assert.doesNotThrow(makeBlock(assert.deepEqual, new String('a'), ['a']));
+  assert.doesNotThrow(makeBlock(assert.deepEqual, new String('a'), {0: 'a'}));
+  assert.doesNotThrow(makeBlock(assert.deepEqual, new Number(1), {}));
+  assert.doesNotThrow(makeBlock(assert.deepEqual, new Boolean(true), {}));
 });
 
 function thrower(errorConstructor) {


### PR DESCRIPTION
`Object.keys` is changed in ES6. It no longer throws errors for primitives.
http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.keys

Next Chrome 40 and Firefox 35 will change `Object.keys` for ES6.
- Chrome (V8): https://code.google.com/p/v8/issues/detail?id=3443
- Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1038545

and then, `assert.deepEqual` will be broken.

FYI: io.js has fixed same issue https://github.com/iojs/io.js/pull/193
