### PR TITLE
Remove explicit util dependency.

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -68,7 +68,7 @@ function isBuffer(b) {
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var util = require('util/');
+var util = require('util');
 var hasOwn = Object.prototype.hasOwnProperty;
 var pSlice = Array.prototype.slice;
 var functionsHaveNames = (function () {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "url": "git://github.com/defunctzombie/commonjs-assert.git"
   },
   "main": "./assert.js",
-  "dependencies": {
-    "util": "0.10.3"
-  },
   "devDependencies": {
     "mocha": "~1.21.4",
     "zuul": "~3.10.0",

--- a/test.js
+++ b/test.js
@@ -307,7 +307,7 @@ function tests (assert, what) {
       testAssertionMessage(new Buffer([1, 2, 3]), '<Buffer 01 02 03>');
       if (typeof global.Uint8Array === 'function' && Object.getOwnPropertyNames( new Uint8Array([])).length === 0) {
         // todo fix util.inspect
-        testAssertionMessage(new Uint8Array([1, 2, 3]), '{ \'0\': 1, \'1\': 2, \'2\': 3 }');
+        testAssertionMessage(new Uint8Array([1, 2, 3]), 'Uint8Array [ 1, 2, 3 ]');
       }
       testAssertionMessage(/a/, '/a/');
       testAssertionMessage(function f() {}, '[Function: f]');


### PR DESCRIPTION
`assert` depended on the userland `util` module rather than browserify's
builtin, which could cause two different versions of `util` could be
included in bundles, if browserify's version doesn't exactly match
`assert`'s dependency.

Since `util` is builtin in Node and in bundlers, we can safely use it
instead of explicitly depending on it.