### PR TITLE
Expose strict mode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,43 @@ This module is used for writing unit tests for your applications, you can access
 It aims to be fully compatibe with the [node.js assert module](http://nodejs.org/api/assert.html), same API and same behavior, just adding support for web browsers.
 The API and code may contain traces of the [CommonJS Unit Testing 1.0 spec](http://wiki.commonjs.org/wiki/Unit_Testing/1.0) which they were based on, but both have evolved significantly since then.
 
+A `strict` and a `legacy` mode exist, while it is recommended to only use `strict mode`.
+
+## Strict mode
+
+When using the `strict mode`, any `assert` function will use the equality used in the strict function mode. So `assert.deepEqual()` will, for example, work the same as `assert.deepStrictEqual()`.
+
+It can be accessed using:
+
+```js
+const assert = require('assert').strict;
+```
+
+## Legacy mode
+
+> Deprecated: Use strict mode instead.
+
+When accessing `assert` directly instead of using the `strict` property, the
+[Abstract Equality Comparison](https://tc39.github.io/ecma262/#sec-abstract-equality-comparison) will be used for any function without a
+"strict" in its name (e.g. `assert.deepEqual()`).
+
+It can be accessed using:
+
+```js
+const assert = require('assert');
+```
+
+It is recommended to use the `strict mode` instead as the Abstract Equality Comparison can often have surprising results. Especially
+in case of `assert.deepEqual()` as the used comparison rules there are very lax.
+
+E.g.
+
+```js
+// WARNING: This does not throw an AssertionError!
+assert.deepEqual(/a/gi, new Date());
+```
+
+
 ## assert.fail(actual, expected, message, operator)
 Throws an exception that displays the values for actual and expected separated by the provided operator.
 

--- a/assert.js
+++ b/assert.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var objectAssign = require('object-assign');
+
 // compare and isBuffer taken from https://github.com/feross/buffer/blob/680e9e5e488f22aac27599a57dc844a6315928dd/index.js
 // original notice:
 
@@ -487,7 +489,7 @@ assert.ifError = function(err) { if (err) throw err; };
 function strict(value, message) {
   if (!value) fail(value, true, message, '==', strict);
 }
-assert.strict = Object.assign(strict, assert, {
+assert.strict = objectAssign(strict, assert, {
   equal: assert.strictEqual,
   deepEqual: assert.deepStrictEqual,
   notEqual: assert.notStrictEqual,

--- a/assert.js
+++ b/assert.js
@@ -483,6 +483,18 @@ assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
 
 assert.ifError = function(err) { if (err) throw err; };
 
+// Expose a strict only variant of assert
+function strict(value, message) {
+  if (!value) fail(value, true, message, '==', strict);
+}
+assert.strict = Object.assign(strict, assert, {
+  equal: assert.strictEqual,
+  deepEqual: assert.deepStrictEqual,
+  notEqual: assert.notStrictEqual,
+  notDeepEqual: assert.notDeepStrictEqual
+});
+assert.strict.strict = assert.strict;
+
 var objectKeys = Object.keys || function (obj) {
   var keys = [];
   for (var key in obj) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "main": "./assert.js",
   "dependencies": {
+    "object-assign": "^4.1.1",
     "util": "0.10.3"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -342,4 +342,19 @@ function tests (assert, what) {
         assert.equal(e.toString().split('\n')[0], 'AssertionError: oh no');
       }
     });
+
+    test('assert - strict mode', function () {
+      var assertStrict = assert.strict;
+
+      assertStrict.throws(makeBlock(assertStrict.equal, 1, true), assertStrict.AssertionError);
+      assertStrict.notEqual(0, false);
+      assertStrict.throws(makeBlock(assertStrict.deepEqual, 1, true), assertStrict.AssertionError);
+      assertStrict.notDeepEqual(0, false);
+      assertStrict.equal(assertStrict.strict, assertStrict.strict.strict);
+      assertStrict.equal(assertStrict.equal, assertStrict.strictEqual);
+      assertStrict.equal(assertStrict.deepEqual, assertStrict.deepStrictEqual);
+      assertStrict.equal(assertStrict.notEqual, assertStrict.notStrictEqual);
+      assertStrict.equal(assertStrict.notDeepEqual, assertStrict.notDeepStrictEqual);
+      assertStrict.equal(Object.keys(assertStrict).length, Object.keys(assert).length);
+    });
 }


### PR DESCRIPTION
This PR adds support for using `assert` in strict mode.

Resolves: #37 
Makes some progress towards: https://github.com/browserify/commonjs-assert/issues/32 

Ported from this Node.js PR: https://github.com/nodejs/node/pull/17002

Tests are all failing. This isn't due to any changes in this PR they are already failing in master: https://github.com/browserify/commonjs-assert/issues/33

I've tested locally on a couple of different Node.js versions and tests are passing but would feel a lot more confident getting this properly tested against all browser targets.

Happy to look into the Travis issue and submit a separate PR resolving that if you want.