### PR TITLE
Safely update npm on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 before_install:
-  - nvm install-latest-npm
+  # Old npm certs are untrusted https://github.com/npm/npm/issues/20191
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "0.8" ]; then export NPM_CONFIG_STRICT_SSL=false; fi'
+  - 'nvm install-latest-npm'
 matrix:
   include:
   - node_js: '0.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 before_install:
-  # Old npm certs are untrusted https://github.com/npm/npm/issues/20191
-  - 'if [ "${TRAVIS_NODE_VERSION}" = "0.8" ]; then export NPM_CONFIG_STRICT_SSL=false; fi'
-  - 'nvm install-latest-npm'
+  - nvm install-latest-npm
 matrix:
   include:
   - node_js: '0.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+before_install:
+  - nvm install-latest-npm
 matrix:
   include:
   - node_js: '0.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-before_install:
-  - npm install -g npm@2
-  - npm install -g npm
 matrix:
   include:
   - node_js: '0.8'


### PR DESCRIPTION
This resolves most of the failing tests on Travis.

Resolves #33 

On Travis we update `npm` before running any tests. The latest versions of `npm` use syntax that isn't available on the Node.js versions we test against so it kills the Travis instance before the tests even begin:

```
$ npm install -g npm
/home/travis/.nvm/versions/node/v5.12.0/bin/npm -> /home/travis/.nvm/versions/node/v5.12.0/lib/node_modules/npm/bin/npm-cli.js
/home/travis/.nvm/versions/node/v5.12.0/bin/npx -> /home/travis/.nvm/versions/node/v5.12.0/lib/node_modules/npm/bin/npx-cli.js
npm@6.9.0 /home/travis/.nvm/versions/node/v5.12.0/lib/node_modules/npm
/home/travis/.nvm/versions/node/v5.12.0/lib/node_modules/npm/bin/npm-cli.js:84
      let notifier = require('update-notifier')({pkg})
      ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

Just removing the `npm` updates form `.travis.yml` resolves this.

There are two remaining tests that still fail, however these are due to `zuul` and `zuul-ngrok` no longer running on these old Node.js versions.

`zuul` hasn't been updated in about a year and looks to have been replaced by [`airtap`](https://github.com/airtap/airtap) which is actively maintained.