### PR TITLE
Remove duplicate line under usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ To use this module directly (without browserify), install it as a dependency:
 npm install assert
 ```
 
-## Usage
-
-The goal is to provide an API that is as functionally identical to the [Node.js `assert` API](https://nodejs.org/api/assert.html) as possible. Read the [official docs](https://nodejs.org/api/assert.html) for API documentation.
-
-### Inconsistencies with Node.js `assert`
+## Inconsistencies with Node.js `assert`
 
 Due to differences between browsers, some error properties such as `message` and `stack` will be inconsistent. However the assertion behaviour is as close as possible to Node.js and the same error `code` will always be used.
 


### PR DESCRIPTION
The line below is already there after the description.

> The goal is to provide an API that is as functionally identical to the [Node.js `assert` API](https://nodejs.org/api/assert.html) as possible. Read the [official docs](https://nodejs.org/api/assert.html) for API documentation.