### PR TITLE
Update all `require('util/')` to be `require('util') because the trailing slash isn't needed

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -31,8 +31,8 @@ const { codes: {
   ERR_MISSING_ARGS
 } } = require('./internal/errors');
 const AssertionError = require('./internal/assert/assertion_error');
-const { inspect } = require('util/');
-const { isPromise, isRegExp } = require('util/').types;
+const { inspect } = require('util');
+const { isPromise, isRegExp } = require('util').types;
 
 const objectAssign = Object.assign ? Object.assign : require('es6-object-assign').assign;
 const objectIs = Object.is ? Object.is : require('object-is');

--- a/internal/assert/assertion_error.js
+++ b/internal/assert/assertion_error.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-const { inspect } = require('util/');
+const { inspect } = require('util');
 const { codes: {
   ERR_INVALID_ARG_TYPE
 } } = require('../errors');

--- a/internal/errors.js
+++ b/internal/errors.js
@@ -115,7 +115,7 @@ createErrorType('ERR_INVALID_ARG_TYPE',
     return msg;
   }, TypeError);
 createErrorType('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
-  if (util === undefined) util = require('util/');
+  if (util === undefined) util = require('');
   let inspected = util.inspect(value);
   if (inspected.length > 128) {
     inspected = `${inspected.slice(0, 128)}...`;

--- a/internal/util/comparisons.js
+++ b/internal/util/comparisons.js
@@ -47,7 +47,7 @@ const {
   isSymbolObject,
   isFloat32Array,
   isFloat64Array
-} = require('util/').types;
+} = require('util').types;
 
 function isNonIndex(key) {
   if (key.length === 0 || key.length > 10)

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -9,7 +9,7 @@
 
 const common = require('../common');
 const assert = require('../../assert');
-const util = require('util/');
+const util = require('util');
 const { AssertionError } = assert;
 const defaultMsgStart = 'Expected values to be strictly deep-equal:\n';
 const defaultMsgStartFull = `${defaultMsgStart}+ actual - expected`;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -36,7 +36,7 @@ const arrayFill = require('array-fill');
 
 const common = require('../common');
 const assert = require('../../assert');
-const { inspect } = require('util/');
+const { inspect } = require('util');
 // [browserify]
 // const { internalBinding } = require('internal/test/binding');
 const a = assert;


### PR DESCRIPTION
While working on a project using a new bundler, we discovered that the presence of the trailing slash is breaking the bundler. Since that trailing slash isn't needed, I'm proposing removing it from all `require('util')` statements.